### PR TITLE
♻️ Refactor Pathfinding to get rid of UnsafeIL.Add

### DIFF
--- a/libs/pathfinding/IGas.cs
+++ b/libs/pathfinding/IGas.cs
@@ -1,0 +1,6 @@
+namespace Cusco.Pathfinding;
+
+public interface IGas<TSelf, T> : IComparable<TSelf> where TSelf : IGas<TSelf, T>
+{
+  public TSelf Add(TSelf rhs);
+}

--- a/libs/pathfinding/IGraphView.cs
+++ b/libs/pathfinding/IGraphView.cs
@@ -1,9 +1,9 @@
 namespace Cusco.Pathfinding;
 
-public interface IGraphView<TNode, TGas>
-  where TGas : struct, IComparable<TGas>
+public interface IGraphView<TNode, TIGas, TGas>
+  where TIGas : struct, IGas<TIGas, TGas>
 {
   bool Contains(TNode node);
-  TGas? GetCost(TNode start, TNode end, TGas gasSoFar);
+  TIGas? GetCost(TNode start, TNode end, TIGas gasSoFar);
   IEnumerable<TNode> GetNeighbours(TNode node);
 }

--- a/libs/unsafe-il/ILMethods.il
+++ b/libs/unsafe-il/ILMethods.il
@@ -25,14 +25,4 @@
     conv.u
     ret
   }
-
-  .method public hidebysig static !!T Add<valuetype T>([in] !!T 'lhs', [in] !!T 'rhs') cil managed aggressiveinlining
-  {
-    .param [2]
-    .maxstack 2
-    ldarg.0
-    ldarg.1
-    add
-    ret
-  }
 }


### PR DESCRIPTION
# What's new ?

- ♻️ Using generics with interfaces to get rid of UnsafeIL.Add while keeping low-garbage Pathfinding
- Breaking change:
  - Use a wrapping type for your gas, like so:
    ```csharp
    public readonly record struct IntGas(int value) : IGas<IntGas, int> {
        // implement interface
    }
    ```
  - Using structs for the gas-wrapper type is recommended as it produces zero garbage (thanks to generics)
  - You need to return the gas-wrapper type in your heuristic method.

# Additional checks / In-depth review

- (nothing in particular)
